### PR TITLE
fix become() so node keeps id of root

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -17,6 +17,8 @@ let s = new Sequence("0", [
   }
 ]);
 
+// s = new Sequence("0")
+
 s.become('cmd');
 
 export default s;

--- a/src/ordts/sequence.js
+++ b/src/ordts/sequence.js
@@ -62,6 +62,10 @@ export class Sequence {
     this.currentLamport = lamport;
   }
 
+  rootId() {
+    return this.atoms.map(a => a.type === 'root' ? a.id : null)[0]
+  }
+
   nextId() {
     return {
       site: this.id,
@@ -229,7 +233,7 @@ export class Sequence {
       this.insertAtom(atom);
     }
 
-    let prevId = index[start-1] || null;
+    let prevId = index.length === 0 ? this.rootId() : index[start-1] || null;
     for (let i = start; i < str.length - back; i++) {
       let id = this.nextId();
       let atom = {
@@ -242,6 +246,7 @@ export class Sequence {
       };
       prevId = id;
       fresh.push(atom);
+      console.log('become loop: fresh =', fresh)
       this.insertAtom(atom);
     }
 


### PR DESCRIPTION
`Sequence.become(str)` method of (sequence.js @ de1223c3a5afc4631bad36c1d42729d0ecb6d6e7) calculates and applies nodes needed to transform current causal tree (weave) to match given `str`.

When inserting a new node into an "empty" `Sequence` / CT containing only the `root` placeholder node, the new node's `prevId` should point to the `id` of the root node, but `become()` was setting it to null. This caused some of the react components that depended on `prevId` to crash.

This PR causes `become()` to check to see if the tree is "empty" except for a node of type `root`, and if so, sets the next created node's `prevId` to root's `id`.

problem:
![Screen Shot 2020-02-05 at 1 34 52 PM](https://user-images.githubusercontent.com/57006/73885262-4c9f1680-481c-11ea-8100-56b06eed56ad.png)

fix:
![Screen Shot 2020-02-05 at 1 37 17 PM](https://user-images.githubusercontent.com/57006/73885447-a273be80-481c-11ea-96cd-44e0766a87b7.png)

Thanks for sharing this codebase!
